### PR TITLE
Standardize event names

### DIFF
--- a/contracts/koin/koin.cpp
+++ b/contracts/koin/koin.cpp
@@ -259,7 +259,7 @@ token::transfer_result transfer( const token::transfer_arguments< constants::max
    std::vector< std::string > impacted;
    impacted.push_back( to );
    impacted.push_back( from );
-   koinos::system::event( "koin.transfer", transfer_event, impacted );
+   koinos::system::event( "koinos.contracts.token.transfer_event", transfer_event, impacted );
 
    return token::transfer_result();
 }
@@ -307,7 +307,7 @@ token::mint_result mint( const token::mint_arguments< constants::max_address_siz
 
    std::vector< std::string > impacted;
    impacted.push_back( to );
-   koinos::system::event( "koin.mint", mint_event, impacted );
+   koinos::system::event( "koinos.contracts.token.mint_event", mint_event, impacted );
 
    return token::mint_result();
 }
@@ -355,7 +355,7 @@ token::burn_result burn( const token::burn_arguments< constants::max_address_siz
 
    std::vector< std::string > impacted;
    impacted.push_back( from );
-   koinos::system::event( "koin.burn", burn_event, impacted );
+   koinos::system::event( "koinos.contracts.token.burn_event", burn_event, impacted );
 
    return token::burn_result();
 }


### PR DESCRIPTION
Resolves #79.

## Brief description
Event names will be standardize to their fully qualified protobuf message name.

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests
